### PR TITLE
Fix module errors

### DIFF
--- a/pkg/homepage/NewHomeComponent.vue
+++ b/pkg/homepage/NewHomeComponent.vue
@@ -1,6 +1,6 @@
 <script>
 export default {
-  name: 'new-home-page',
+  name:   'NewHomePage',
   layout: 'plain'
 };
 </script>
@@ -16,4 +16,3 @@ export default {
     text-align: center;
   }
 </style>
-

--- a/pkg/homepage/index.ts
+++ b/pkg/homepage/index.ts
@@ -17,5 +17,5 @@ export default function(plugin: IPlugin) {
     name:      'home',
     path:      '/home',
     component: NewHomeComponent
-  });  
+  });
 }

--- a/pkg/new-feature/NewFeature.vue
+++ b/pkg/new-feature/NewFeature.vue
@@ -1,6 +1,6 @@
 <script>
 export default {
-  name: 'new-home-page',
+  name:   'NewHomePage',
   layout: 'plain'
 };
 </script>
@@ -14,4 +14,3 @@ export default {
     text-align: center;
   }
 </style>
-

--- a/pkg/new-feature/index.ts
+++ b/pkg/new-feature/index.ts
@@ -17,5 +17,5 @@ export default function(plugin: IPlugin) {
     name:      'new-feature',
     path:      '/new-feature',
     component: NewFeature
-  });   
+  });
 }


### PR DESCRIPTION
This fixes several several module errors that I encountered while building for dev. Including but not limited to:

```
ERROR  in ./pkg/new-feature/NewFeature.vue                                                      friendly-errors 13:55:17

Module Error (from ./node_modules/eslint-loader/dist/cjs.js):                                    friendly-errors 13:55:17

/home/phillip/Development/rancher-plugins-example/pkg/new-feature/NewFeature.vue
   3:9  warning  Missing space before value for key 'name'                  key-spacing
   3:9  warning  Property name "new-home-page" is not PascalCase            vue/component-definition-name-casing
  17:1  error    Too many blank lines at the end of file. Max of 0
  allowed  no-multiple-empty-lines
```

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>