### PR TITLE
Revert "add display-name annotation to clock v2"

### DIFF
--- a/charts/clock/0.2.0/Chart.yaml
+++ b/charts/clock/0.2.0/Chart.yaml
@@ -1,5 +1,4 @@
 annotations:
-  catalog.cattle.io/display-name: Clock Ext
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
   catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=

--- a/index.yaml
+++ b/index.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 entries:
   clock:
   - annotations:
-      catalog.cattle.io/display-name: Clock Ext
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.28.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system


### PR DESCRIPTION
This reverts commit f46a8ea0755f893374ab038d4527c66825f44d80.

Required to fix dashboard e2e tests