### PR TITLE
Update dependencies with latest rancher components and shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "ui-plugin-examples",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "engines": {
     "node": ">=12"
   },
   "dependencies": {
-    "@rancher/components": "0.1.0-alpha.9",
-    "@rancher/shell": "0.3.29",
+    "@rancher/components": "0.2.1-alpha.0",
+    "@rancher/shell": "0.5.2",
     "@types/lodash": "4.14.184",
     "core-js": "3.21.1",
     "css-loader": "4.3.0"
@@ -21,8 +21,9 @@
     "serve-pkgs": "./node_modules/@rancher/shell/scripts/serve-pkgs",
     "publish-pkgs": "./node_modules/@rancher/shell/scripts/extension/publish"
   },
-  "resolutions": {
-    "**/webpack": "4",
-    "@types/node": "16"
+  "devDependencies": {
+    "@types/node": "18.11.9",
+    "@types/semver": "^7.5.8",
+    "semver": "^7.6.0"
   }
 }

--- a/pkg/clock/package.json
+++ b/pkg/clock/package.json
@@ -1,13 +1,13 @@
 {
   "name": "clock",
   "description": "Adds a new feature to the top-level menu that shows a full-page clock",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/clock/clock.svg",
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -18,9 +18,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/extension-crd/package.json
+++ b/pkg/extension-crd/package.json
@@ -1,13 +1,13 @@
 {
   "name": "extension-crd",
   "description": "Adds support for the Rancher Extensions CRD to Rancher Manager",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/extension-crd/icon.svg",
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -18,9 +18,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/extensions-api-demo/package.json
+++ b/pkg/extensions-api-demo/package.json
@@ -1,12 +1,12 @@
 {
   "name": "extensions-api-demo",
   "description": "Extensions Api demo extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -17,9 +17,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/homepage/NewHomeComponent.vue
+++ b/pkg/homepage/NewHomeComponent.vue
@@ -8,7 +8,7 @@ export default {
   <div>
     <h1>Welcome to Rancher</h1>
     <img src="./assets/rancher-logo.svg" height="64" />
-    <h3>Home Page Extension 0.3.0</h3>
+    <h3>Home Page Extension 0.4.0</h3>
     <img src="./assets/rancher-home-animated.svg" />
   </div>
 </template>

--- a/pkg/homepage/package.json
+++ b/pkg/homepage/package.json
@@ -1,12 +1,12 @@
 {
   "name": "homepage",
   "description": "Example extension that changes the landing home page",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/homepage/homepage.svg",
@@ -18,9 +18,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/large-extension/package.json
+++ b/pkg/large-extension/package.json
@@ -1,13 +1,13 @@
 {
   "name": "large-extension",
   "description": "Adds a new feature to the top-level menu that shows a large image (extension larger than 20mb - used for testing)",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/large-extension/clock.svg",
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -18,9 +18,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/node-driver/package.json
+++ b/pkg/node-driver/package.json
@@ -1,12 +1,12 @@
 {
   "name": "openstack",
   "description": "Example node driver UI for Openstack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -17,9 +17,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/top-level-product/package.json
+++ b/pkg/top-level-product/package.json
@@ -1,12 +1,12 @@
 {
   "name": "top-level-product",
   "description": "Example extension for a top-level product on Rancher Dashboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -17,9 +17,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/pkg/uk-locale/package.json
+++ b/pkg/uk-locale/package.json
@@ -1,13 +1,13 @@
 {
   "name": "uk-locale",
   "description": "Adds a new UK localisation",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/uk-locale/uk-locale.svg",
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.0-0"
+      "catalog.cattle.io/rancher-version": ">= 2.8.0-0"
     }
   },
   "scripts": {
@@ -18,9 +18,9 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/cli-plugin-typescript": "^4.5.15"
+    "@vue/cli-plugin-babel": "5.0.8",
+    "@vue/cli-service": "5.0.8",
+    "@vue/cli-plugin-typescript": "5.0.8"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
This bumps the versions of the primary package.json and the pkg package.json files to match those found in other current Rancher extensions such as Elemental: https://github.com/rancher/elemental-ui/blob/main/package.json.
Also used in third party App Launcher extension https://github.com/krumIO/krum-rancher-extensions

All extensions appear working except for the homepage extension, without updating the /home route. If changing the /home route, the homepage extension works fine. The /home route does appear to properly override the default /home route in the current Rancher version.