### PR TITLE
add reusable workflow to the repo to allow for tagged publish of examples

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -20,3 +20,4 @@ jobs:
       pages: write
     with:
       target_branch: main
+      tagged_release: ${{ github.ref_name }}"

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -1,0 +1,22 @@
+name: Build and Release Extension Charts
+
+on:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./
+
+jobs:
+  build-extension-charts:
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@release-2.9
+    permissions:
+      actions: write
+      contents: write
+      deployments: write
+      pages: write
+    with:
+      target_branch: main


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/12027

add reusable workflow to the repo to allow for tagged publish of examples