### PR TITLE
Bump all versions of extensions to do a publish with the proper workflow

### DIFF
--- a/pkg/clock/package.json
+++ b/pkg/clock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clock",
   "description": "Adds a new feature to the top-level menu that shows a full-page clock",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/extension-crd/package.json
+++ b/pkg/extension-crd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "extension-crd",
   "description": "Adds support for the Rancher Extensions CRD to Rancher Manager",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/extension-crd/icon.svg",
   "rancher": {

--- a/pkg/extensions-api-demo/package.json
+++ b/pkg/extensions-api-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "extensions-api-demo",
   "description": "Extensions Api demo extension",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/homepage/package.json
+++ b/pkg/homepage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homepage",
   "description": "Example extension that changes the landing home page",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/large-extension/package.json
+++ b/pkg/large-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "large-extension",
   "description": "Adds a new feature to the top-level menu that shows a large image (extension larger than 20mb - used for testing)",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/large-extension/clock.svg",
   "rancher": {

--- a/pkg/top-level-product/package.json
+++ b/pkg/top-level-product/package.json
@@ -1,7 +1,7 @@
 {
   "name": "top-level-product",
   "description": "Example extension for a top-level product on Rancher Dashboard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/uk-locale/package.json
+++ b/pkg/uk-locale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uk-locale",
   "description": "Adds a new UK localisation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "icon": "https://raw.githubusercontent.com/rancher/ui-plugin-examples/main/pkg/uk-locale/uk-locale.svg",
   "rancher": {


### PR DESCRIPTION
Bump all versions of extensions to do a publish with the proper workflow which should enable annotation propagation to the `UIplugin` resource, which is needed for some checks with the `shouldNotLoadPlugin` method in Dashboard