### PR TITLE
Add an 'experimental' label to an extension

### DIFF
--- a/pkg/extensions-api-demo/package.json
+++ b/pkg/extensions-api-demo/package.json
@@ -1,13 +1,14 @@
 {
   "name": "extensions-api-demo",
   "description": "Extensions Api demo extension",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "rancher": {
     "annotations": {
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
       "catalog.cattle.io/rancher-version": ">= 2.10.0-0",
-      "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0"
+      "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0",
+      "catalog.cattle.io/experimental": "true"
     }
   },
   "scripts": {


### PR DESCRIPTION
We need an extension with the experimental label on its latest version to fully validate https://github.com/rancher/dashboard/issues/14080

This PR adds the label to the extensions-api-demo extension, and publishes a new version.


NOTE: it would be good to verify what I did in the last commit of this pr...when I ran `yarn publish-pkgs` the node driver and openstack extension also rebuilt for reasons unknown (to me). I did not include those files, and I removed what I assume are incorrect changes to assets/index.yaml?