### PR TITLE
add input create_pr to create a PR instead of doing a direct release

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       target_branch: main
       tagged_release: ${{ github.ref_name }}
+      create_pr: 'true'


### PR DESCRIPTION
add input `create_pr` to create a PR instead of doing a direct release to `main` as it's a protected branch

Updates to the reusable workflow in `master` dashboard have already been merged: https://github.com/rancher/dashboard/pull/14794

