### PR TITLE
Security hardening examples repo

### DIFF
--- a/.github/workflows/create-pr-build-extension-charts.yml
+++ b/.github/workflows/create-pr-build-extension-charts.yml
@@ -16,8 +16,6 @@ jobs:
     permissions:
       actions: write
       contents: write
-      deployments: write
-      pages: write
       pull-requests: write
     with:
       target_branch: main

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,13 +20,13 @@ jobs:
     # The FOSSA token is shared between all repos in Rancher's GH org. It can be
     # used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       with:
         secrets: |
           secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
-      uses: fossas/fossa-action@main
+      uses: fossas/fossa-action@c414b9ad82eaad041e47a7cf62a4f02411f427a0 # v1.8.0
       with:
         api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
         # Only runs the scan and do not provide/returns any results back to the

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The extensions should then appear on the 'Extensions' page in Rancher Manager.
 
 You can build and run the extensions locally, to do so:
 
-- Run `yarn install`
+- Run `yarn install --frozen-lockfile`
 - Set the API environment variable to point to a Rancher backend
 - Run Rancher in development mode with `yarn dev`
 - Open a web browser to `https://127.0.0.1:8005`

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   },
   "dependencies": {
     "@rancher/shell": "3.0.8",
-    "cache-loader": "^4.1.0",
+    "cache-loader": "4.1.0",
     "color": "4.2.3",
     "ip": "2.0.1",
-    "node-polyfill-webpack-plugin": "^3.0.0"
+    "node-polyfill-webpack-plugin": "3.0.0"
   },
   "resolutions": {
-    "@types/node": "~20.10.0",
+    "@types/node": "20.10.8",
     "@types/lodash": "4.17.5"
   },
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/17509

- pin workflow actions to SHA
- docs with yarn install --frozen-lockfile
- reduce workflow permissions to minimum needed 
- pin node dependencies